### PR TITLE
Add mllog for training

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ pytest
 tensorflow==2.15.0
 tensorflow-datasets
 ruff>=0.1.5<=0.2
+git+https://github.com/mlperf/logging.git

--- a/src/maxdiffusion/configs/base21.yml
+++ b/src/maxdiffusion/configs/base21.yml
@@ -103,8 +103,7 @@ output_dir: 'sd-model-finetuned'
 tensorboard_dir: 'gs://shahrokhi-maxdiffusion-v5'
 per_device_batch_size: 1
 
-cosine_learning_rate_final_fraction: 0.1 
-warmup_steps_fraction: 0.1
+warmup_steps_fraction: 0.0
 learning_rate_schedule_steps: -1 # By default the length of the schedule is set to the number of steps.
 
 # However you may choose a longer schedule (learning_rate_schedule_steps > steps), in which case the training will end before 
@@ -115,8 +114,6 @@ adam_b1: 0.9 # Exponential decay rate to track the first moment of past gradient
 adam_b2: 0.999 # Exponential decay rate to track the second moment of past gradients.
 adam_eps: 1.e-8 # A small constant applied to denominator outside of the square root.
 adam_weight_decay: 1.e-2 # AdamW Weight decay
-
-max_grad_norm: 1.0
 
 enable_profiler: True
 # Skip first n steps for profiling, to omit things like compilation and to give
@@ -131,4 +128,3 @@ prompt: "A magical castle in the middle of a forest, artistic drawing"
 negative_prompt: "purple, red"
 guidance_scale: 7.5
 num_inference_steps: 30
-seed: 47

--- a/src/maxdiffusion/configs/base_2_base.yml
+++ b/src/maxdiffusion/configs/base_2_base.yml
@@ -113,8 +113,7 @@ output_dir: 'sd-model-finetuned'
 tensorboard_dir: 'gs://shahrokhi-maxdiffusion-v5'
 per_device_batch_size: 1
 
-cosine_learning_rate_final_fraction: 0.1 
-warmup_steps_fraction: 0.1
+warmup_steps_fraction: 0.0
 learning_rate_schedule_steps: -1 # By default the length of the schedule is set to the number of steps.
 
 # However you may choose a longer schedule (learning_rate_schedule_steps > steps), in which case the training will end before 
@@ -125,8 +124,6 @@ adam_b1: 0.9 # Exponential decay rate to track the first moment of past gradient
 adam_b2: 0.999 # Exponential decay rate to track the second moment of past gradients.
 adam_eps: 1.e-8 # A small constant applied to denominator outside of the square root.
 adam_weight_decay: 1.e-2 # AdamW Weight decay
-
-max_grad_norm: 1.0
 
 enable_profiler: True
 # Skip first n steps for profiling, to omit things like compilation and to give
@@ -139,4 +136,3 @@ prompt: "A magical castle in the middle of a forest, artistic drawing"
 negative_prompt: "purple, red"
 guidance_scale: 7.5
 num_inference_steps: 30
-seed: 47

--- a/src/maxdiffusion/configs/base_2_base_inference.yml
+++ b/src/maxdiffusion/configs/base_2_base_inference.yml
@@ -103,8 +103,7 @@ output_dir: 'sd-model-finetuned'
 tensorboard_dir: 'gs://shahrokhi-maxdiffusion-v5'
 per_device_batch_size: 1
 
-cosine_learning_rate_final_fraction: 0.1 
-warmup_steps_fraction: 0.1
+warmup_steps_fraction: 0.0
 learning_rate_schedule_steps: -1 # By default the length of the schedule is set to the number of steps.
 
 # However you may choose a longer schedule (learning_rate_schedule_steps > steps), in which case the training will end before 
@@ -115,8 +114,6 @@ adam_b1: 0.9 # Exponential decay rate to track the first moment of past gradient
 adam_b2: 0.999 # Exponential decay rate to track the second moment of past gradients.
 adam_eps: 1.e-8 # A small constant applied to denominator outside of the square root.
 adam_weight_decay: 1.e-2 # AdamW Weight decay
-
-max_grad_norm: 1.0
 
 enable_profiler: True
 # Skip first n steps for profiling, to omit things like compilation and to give
@@ -129,4 +126,3 @@ prompt: "A magical castle in the middle of a forest, artistic drawing"
 negative_prompt: "purple, red"
 guidance_scale: 7.5
 num_inference_steps: 30
-seed: 47

--- a/src/maxdiffusion/configs/base_xl.yml
+++ b/src/maxdiffusion/configs/base_xl.yml
@@ -92,8 +92,7 @@ seed: 0
 output_dir: 'sdxl-model-finetuned'
 per_device_batch_size: 2
 
-cosine_learning_rate_final_fraction: 0.1 
-warmup_steps_fraction: 0.1
+warmup_steps_fraction: 0.0
 learning_rate_schedule_steps: -1 # By default the length of the schedule is set to the number of steps.
 
 # However you may choose a longer schedule (learning_rate_schedule_steps > steps), in which case the training will end before 
@@ -104,8 +103,6 @@ adam_b1: 0.9 # Exponential decay rate to track the first moment of past gradient
 adam_b2: 0.999 # Exponential decay rate to track the second moment of past gradients.
 adam_eps: 1.e-8 # A small constant applied to denominator outside of the square root.
 adam_weight_decay: 1.e-2 # AdamW Weight decay
-
-max_grad_norm: 1.0
 
 enable_profiler: True
 # Skip first n steps for profiling, to omit things like compilation and to give
@@ -118,7 +115,6 @@ prompt: "A magical castle in the middle of a forest, artistic drawing"
 negative_prompt: "purple, red"
 guidance_scale: 9
 num_inference_steps: 20
-seed: 47
 
 # SDXL Lightning parameters
 lightning_from_pt: True

--- a/src/maxdiffusion/configs/base_xl_lightning.yml
+++ b/src/maxdiffusion/configs/base_xl_lightning.yml
@@ -92,8 +92,7 @@ seed: 0
 output_dir: 'sdxl-model-finetuned'
 per_device_batch_size: 2
 
-cosine_learning_rate_final_fraction: 0.1 
-warmup_steps_fraction: 0.1
+warmup_steps_fraction: 0.0
 learning_rate_schedule_steps: -1 # By default the length of the schedule is set to the number of steps.
 
 # However you may choose a longer schedule (learning_rate_schedule_steps > steps), in which case the training will end before 
@@ -104,8 +103,6 @@ adam_b1: 0.9 # Exponential decay rate to track the first moment of past gradient
 adam_b2: 0.999 # Exponential decay rate to track the second moment of past gradients.
 adam_eps: 1.e-8 # A small constant applied to denominator outside of the square root.
 adam_weight_decay: 1.e-2 # AdamW Weight decay
-
-max_grad_norm: 1.0
 
 enable_profiler: True
 # Skip first n steps for profiling, to omit things like compilation and to give
@@ -118,7 +115,6 @@ prompt: "portrait photo of muscular bearded guy in a worn mech suit, light bokeh
 negative_prompt: "purple, red"
 guidance_scale: 2
 num_inference_steps: 4
-seed: 47
 
 # SDXL Lightning parameters
 lightning_from_pt: True

--- a/src/maxdiffusion/mllog_utils.py
+++ b/src/maxdiffusion/mllog_utils.py
@@ -1,0 +1,97 @@
+"""
+ Copyright 2023 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      https://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+"""Utils that relevant to mllog for mlperf submission compliance."""
+import jax
+from mlperf_logging import mllog
+
+mllogger = mllog.get_mllogger()
+
+def train_init_start():
+  if jax.process_index() == 0:
+    mllogger.event(mllog.constants.CACHE_CLEAR)
+    mllogger.start(mllog.constants.INIT_START)
+
+def train_init_stop():
+  if jax.process_index() == 0:
+    mllogger.end(mllog.constants.INIT_STOP)
+
+def train_run_start():
+  if jax.process_index() == 0:
+    mllogger.start(mllog.constants.RUN_START)
+
+def train_run_end():
+  if jax.process_index() == 0:
+    mllogger.end(mllog.constants.RUN_STOP, metadata={'status': 'success'})
+
+def train_init_print(config, device: str = 'tpu-v5p'):
+  """an initial mllog for mlperf sumbission compliance check."""
+  if jax.process_index() == 0:
+    mllogger.event(mllog.constants.SUBMISSION_ORG, 'Google')
+    mllogger.event(mllog.constants.SUBMISSION_PLATFORM, device)
+    mllogger.event(mllog.constants.SUBMISSION_STATUS, mllog.constants.CLOUD)
+    mllogger.event(mllog.constants.SUBMISSION_DIVISION, mllog.constants.CLOSED)
+    mllogger.event(mllog.constants.SUBMISSION_BENCHMARK, mllog.constants.STABLE_DIFFUSION)
+    mllogger.event(mllog.constants.GRADIENT_ACCUMULATION_STEPS, 1)
+    mllogger.event(mllog.constants.GLOBAL_BATCH_SIZE,
+                   config.per_device_batch_size * jax.device_count())
+
+    mllogger.event(mllog.constants.OPT_NAME, mllog.constants.ADAMW)
+    mllogger.event(mllog.constants.OPT_ADAMW_BETA_1, config.adam_b1)
+    mllogger.event(mllog.constants.OPT_ADAMW_BETA_2, config.adam_b2)
+    mllogger.event(mllog.constants.OPT_ADAMW_EPSILON, config.adam_eps)
+    mllogger.event(mllog.constants.OPT_ADAMW_WEIGHT_DECAY, config.adam_weight_decay)
+
+    mllogger.event(mllog.constants.OPT_BASE_LR, config.learning_rate)
+    mllogger.event(mllog.constants.OPT_LR_WARMUP_STEPS,
+                   int(config.learning_rate_schedule_steps * config.warmup_steps_fraction))
+
+    # Training: a subset of laion-400m
+    # Validation: a subset of coco-2014 validation
+    mllogger.event(mllog.constants.TRAIN_SAMPLES, 6513144)
+    mllogger.event(mllog.constants.EVAL_SAMPLES, 30000)
+
+    mllogger.event(mllog.constants.SEED, config.seed)
+
+def train_step_start(step):
+  if jax.process_index() == 0:
+    mllogger.start(
+      mllog.constants.BLOCK_START,
+      value="training_step",
+      metadata={
+        'step_num': step,
+      },
+    )
+
+def train_step_end(step, loss, lr):
+  if jax.process_index() == 0:
+    mllogger.end(
+      mllog.constants.BLOCK_STOP,
+      value="training_step",
+      metadata={
+        'step_num': step,
+        'loss': loss,
+        'lr': lr,
+      },
+    )
+
+def maybe_train_step_log(config, start_step, step, metric, train_log_interval: int = 100):
+  if step > start_step and step % train_log_interval == 0 or step == config.max_train_steps - 1:
+    train_step_end(
+      step,
+      loss=metric['scalar']['learning/loss'],
+      lr=metric['scalar']['learning/current_learning_rate'],
+    )
+    # start new tracking except the last step
+    if step < config.max_train_steps - 1:
+      train_step_start(step)

--- a/src/maxdiffusion/pyconfig.py
+++ b/src/maxdiffusion/pyconfig.py
@@ -102,6 +102,9 @@ class _HyperParameters():
     raw_keys["logical_axis_rules"] = _lists_to_tuples(raw_keys["logical_axis_rules"])
     raw_keys["data_sharding"] = _lists_to_tuples(raw_keys["data_sharding"])
 
+    if raw_keys["learning_rate_schedule_steps"]==-1:
+      raw_keys["learning_rate_schedule_steps"] = raw_keys["max_train_steps"]
+
 def get_num_target_devices(raw_keys):
   return len(jax.devices())
 

--- a/src/maxdiffusion/tests/generate_smoke_test.py
+++ b/src/maxdiffusion/tests/generate_smoke_test.py
@@ -34,7 +34,7 @@ class Generate(unittest.TestCase):
   def test_sd_2_base_config(self):
     img_url = os.path.join(THIS_DIR,'images','test_2_base.png')
     base_image = np.array(Image.open(img_url)).astype(np.uint8)
-    pyconfig.initialize([None,os.path.join(THIS_DIR,'..','configs','base_2_base.yml')])
+    pyconfig.initialize([None,os.path.join(THIS_DIR,'..','configs','base_2_base.yml'), "seed=47"])
     images = generate_run(pyconfig.config)
     test_image = np.array(images[0]).astype(np.uint8)
     ssim_compare = ssim(base_image, test_image,


### PR DESCRIPTION
As titled, mainly to add mllog for training.

Additionally, update the following parts to ensure compliance 
- [x] update warm up schedule according to [the training rules](https://github.com/mlcommons/training_policies/blob/master/training_rules.adoc#91-hyperparameters) and [Nvidia implementation](https://github.com/mlcommons/training_results_v3.1/blob/5b62935b6baecd018180cb3100e65fa90ef7ac98/NVIDIA/benchmarks/stable_diffusion/implementations/pytorch/conf/sd2_mlperf_train_moments.yaml#L193)
![image](https://github.com/google/maxdiffusion/assets/137231034/3197c6d3-b3d9-41f0-8537-4de3e04c2c3a)
- [x] remove  `clip_by_global_norm` which is not allowed in stable diffusion according to [the training rules](https://github.com/mlcommons/training_policies/blob/master/training_rules.adoc#91-hyperparameters) 

Some updates for better readability:
- [x] remove duplicated key `seed` in config
- [x] replace `global_step` with `step` from iterator