### PR TITLE
fix mllog encoding error

### DIFF
--- a/src/maxdiffusion/mllog_utils.py
+++ b/src/maxdiffusion/mllog_utils.py
@@ -14,6 +14,7 @@
 """Utils that relevant to mllog for mlperf submission compliance."""
 import jax
 from mlperf_logging import mllog
+import numpy as np
 
 mllogger = mllog.get_mllogger()
 
@@ -87,11 +88,11 @@ def train_step_end(step, loss, lr):
 
 def maybe_train_step_log(config, start_step, step, metric, train_log_interval: int = 100):
   if step > start_step and step % train_log_interval == 0 or step == config.max_train_steps - 1:
-    train_step_end(
-      step,
-      loss=metric['scalar']['learning/loss'],
-      lr=metric['scalar']['learning/current_learning_rate'],
-    )
+    # convert the jax array to a numpy array for mllog JSON encoding
+    loss = np.asarray(metric['scalar']['learning/loss'])
+    lr = np.asarray(metric['scalar']['learning/current_learning_rate'])
+
+    train_step_end(step, loss, lr)
     # start new tracking except the last step
     if step < config.max_train_steps - 1:
       train_step_start(step)


### PR DESCRIPTION
As titled, jax array is not encodable in json which cause the encoding error:
```
Failed to encode: \
['', 1711508257415, 'INTERVAL_END', 'block_stop', 'training_step', \
{'file': '/home/jfacevedo/.local/lib/python3.10/site-packages/maxdiffusion/mllog_utils.py', \
'lineno': 78, 'step_num': 9400, 'loss': Array(0.241467, dtype=float32), \
'lr': Array(1.e-07, dtype=float32, weak_type=True)}]
```