### PR TITLE
Add mllog for inference, eval, and report_end script

### DIFF
--- a/src/maxdiffusion/metrics/fid/fid_score.py
+++ b/src/maxdiffusion/metrics/fid/fid_score.py
@@ -6,13 +6,16 @@ import os
 import scipy
 from tqdm import tqdm
 from tensorflow.keras.preprocessing.image import ImageDataGenerator
+import tensorflow as tf
 
 IMAGE_EXTENSIONS = {'bmp', 'jpg', 'jpeg', 'pgm', 'png', 'ppm',
                     'tif', 'tiff', 'webp'}
 
 def compute_statistics_with_mmap(path, mmap_filname, params, apply_fn, batch_size=1, img_size=None):
+    # need to read as byte for np.load
     if path.endswith(".npz"):
-        stats = np.load(path)
+        with tf.io.gfile.GFile(path, 'rb') as f:
+            stats = np.load(f)
         mu, sigma = stats["mu"], stats["sigma"]
         return mu, sigma
     
@@ -53,7 +56,9 @@ def compute_statistics_with_mmap(path, mmap_filname, params, apply_fn, batch_siz
 
 def compute_statistics(path, params, apply_fn, batch_size=1, img_size=None):
     if path.endswith(".npz"):
-        stats = np.load(path)
+        # need to read as byte for np.load
+        with tf.io.gfile.GFile(path, 'rb') as f:
+            stats = np.load(f)
         mu, sigma = stats["mu"], stats["sigma"]
         return mu, sigma
 

--- a/src/maxdiffusion/mllog_utils.py
+++ b/src/maxdiffusion/mllog_utils.py
@@ -12,9 +12,11 @@
  """
 
 """Utils that relevant to mllog for mlperf submission compliance."""
+from typing import Optional
 import jax
 from mlperf_logging import mllog
 import numpy as np
+import os
 
 mllogger = mllog.get_mllogger()
 
@@ -64,35 +66,155 @@ def train_init_print(config, device: str = 'tpu-v5p'):
 
     mllogger.event(mllog.constants.SEED, config.seed)
 
-def train_step_start(step):
+def train_step_start(step_num, samples_count):
   if jax.process_index() == 0:
     mllogger.start(
       mllog.constants.BLOCK_START,
       value="training_step",
       metadata={
-        'step_num': step,
+        mllog.constants.STEP_NUM: step_num,
+        mllog.constants.SAMPLES_COUNT: samples_count,
       },
     )
 
-def train_step_end(step, loss, lr):
+def train_step_end(step_num, samples_count, loss, lr):
   if jax.process_index() == 0:
     mllogger.end(
       mllog.constants.BLOCK_STOP,
       value="training_step",
       metadata={
-        'step_num': step,
+        mllog.constants.STEP_NUM: step_num,
+        mllog.constants.SAMPLES_COUNT: samples_count,
         'loss': loss,
         'lr': lr,
       },
     )
 
-def maybe_train_step_log(config, start_step, step, metric, train_log_interval: int = 100):
-  if step > start_step and step % train_log_interval == 0 or step == config.max_train_steps - 1:
+def maybe_train_step_log(config, start_step, step_num, samples_count, metric, train_log_interval: int = 100, ):
+  if step_num > start_step and step_num % train_log_interval == 0 or step_num == config.max_train_steps:
     # convert the jax array to a numpy array for mllog JSON encoding
     loss = np.asarray(metric['scalar']['learning/loss'])
     lr = np.asarray(metric['scalar']['learning/current_learning_rate'])
 
-    train_step_end(step, loss, lr)
+    train_step_end(step_num, samples_count, loss, lr)
     # start new tracking except the last step
-    if step < config.max_train_steps - 1:
-      train_step_start(step)
+    if step_num < config.max_train_steps:
+      train_step_start(step_num, samples_count)
+
+def train_checkpoint_step_log(step_num: int):
+  if jax.process_index() == 0:
+    mllogger.event(
+      "checkpoint",
+      value=step_num,
+      metadata={
+        mllog.constants.STEP_NUM: step_num,
+      },
+    )
+
+def extract_info_from_ckpt_name(model_ckpt_name: str, key: str) -> int:
+  # model_ckpt_name format:
+  #  f"{step_num=}-{samples_count=}"
+  assert key in ("step_num", "samples_count")
+  info_dict = {}
+  for key_value_str in os.path.basename(model_ckpt_name.rstrip('/')).split('-'):
+    key, value = key_value_str.split("=")
+    info_dict[key] = value
+  result = int(info_dict[key])
+  return result
+
+def eval_start(config):
+  if jax.process_index() == 0:
+    step_num = extract_info_from_ckpt_name(config.pretrained_model_name_or_path, "step_num")
+    samples_count = extract_info_from_ckpt_name(config.pretrained_model_name_or_path, "samples_count")
+    mllogger.start(
+      mllog.constants.EVAL_START,
+      metadata={
+        mllog.constants.STEP_NUM: step_num,
+        mllog.constants.SAMPLES_COUNT: samples_count,
+      },
+    )
+
+def eval_end(config):
+  if jax.process_index() == 0:
+    step_num = extract_info_from_ckpt_name(config.pretrained_model_name_or_path, "step_num")
+    samples_count = extract_info_from_ckpt_name(config.pretrained_model_name_or_path, "samples_count")
+    mllogger.end(
+      mllog.constants.EVAL_STOP,
+      metadata={
+        mllog.constants.STEP_NUM: step_num,
+        mllog.constants.SAMPLES_COUNT: samples_count,
+      },
+    )
+
+def eval_fid(config, fid: float):
+  if jax.process_index() == 0:
+    step_num = extract_info_from_ckpt_name(config.pretrained_model_name_or_path, "step_num")
+    samples_count = extract_info_from_ckpt_name(config.pretrained_model_name_or_path, "samples_count")
+    mllogger.event(
+      mllog.constants.EVAL_ACCURACY,
+      value=fid,
+      metadata={
+        mllog.constants.STEP_NUM: step_num,
+        mllog.constants.SAMPLES_COUNT: samples_count,
+        "metric": "FID",
+        "ckpt_name": config.pretrained_model_name_or_path,
+      },
+    )
+
+def eval_clip(config, clip_score: float):
+  if jax.process_index() == 0:
+    step_num = extract_info_from_ckpt_name(config.pretrained_model_name_or_path, "step_num")
+    samples_count = extract_info_from_ckpt_name(config.pretrained_model_name_or_path, "samples_count")
+    mllogger.event(
+      mllog.constants.EVAL_ACCURACY,
+      value=clip_score,
+      metadata={
+        mllog.constants.STEP_NUM: step_num,
+        mllog.constants.SAMPLES_COUNT: samples_count,
+        "metric": "CLIP",
+        "ckpt_name": config.pretrained_model_name_or_path,
+      },
+    )
+
+def timestamp_fid(fid: float, timestamp: int, step_num: int, samples_count: int):
+  mllogger.event(
+    mllog.constants.EVAL_ACCURACY,
+    value=fid,
+    metadata={
+      mllog.constants.STEP_NUM: step_num,
+      mllog.constants.SAMPLES_COUNT: samples_count,
+      "metric": "FID",
+    },
+    time_ms=timestamp,
+  )
+
+def timestamp_clip(clip: float, timestamp: int, step_num: int, samples_count: int):
+  mllogger.event(
+    mllog.constants.EVAL_ACCURACY,
+    value=clip,
+    metadata={
+      mllog.constants.STEP_NUM: step_num,
+      mllog.constants.SAMPLES_COUNT: samples_count,
+      "metric": "CLIP",
+    },
+    time_ms=timestamp,
+  )
+
+def timestamp_run_stop_success(timestamp: int, step_num: int, samples_count: int):
+  mllogger.end(
+    mllog.constants.RUN_STOP,
+    metadata={
+      mllog.constants.STATUS: mllog.constants.SUCCESS,
+      mllog.constants.STEP_NUM: step_num,
+      mllog.constants.SAMPLES_COUNT: samples_count,
+    },
+    time_ms=timestamp,
+  )
+
+def timestamp_run_stop_abort():
+  mllogger.end(
+    mllog.constants.RUN_STOP,
+    metadata={
+      mllog.constants.STATUS: mllog.constants.ABORTED,
+    },
+  )

--- a/src/maxdiffusion/pyconfig.py
+++ b/src/maxdiffusion/pyconfig.py
@@ -90,7 +90,7 @@ class _HyperParameters():
     self.keys = raw_keys
 
   def _load_kwargs(self, argv: list[str], **kwargs):
-    args_dict = dict(a.split("=") for a in argv[2:])
+    args_dict = dict(a.split("=", 1) for a in argv[2:])
     args_dict.update(kwargs)
     return args_dict
 

--- a/src/maxdiffusion/report_end.py
+++ b/src/maxdiffusion/report_end.py
@@ -1,0 +1,88 @@
+"""
+ Copyright 2024 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+   https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+"""Find and output the convergence timestamp and step
+
+Usage:
+
+python src/maxdiffusion/report_end.py \
+    --metrics-path=/path/to/eval_metrics.csv \
+    --mllog-path=/path/to/mllog.txt
+"""
+
+
+import pandas as pd
+import argparse
+import tensorflow as tf
+import json
+import mllog_utils
+
+
+TARGET_FID = 90.0
+TARGET_CLIP = 0.15
+MLLOG_PREFIX=":::MLLOG"
+
+
+def parse_command_line_args():
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--target-fid", type=float, default=TARGET_FID)
+  parser.add_argument("--target-clip", type=float, default=TARGET_CLIP)
+  parser.add_argument("--metrics-path", type=str, required=True)
+  parser.add_argument("--mllog-path", type=str, required=True)
+  args = parser.parse_args()
+  return args
+
+def create_step_num_to_timestamp(mllog_path: str):
+  step_num_to_timestamp = {}
+  with tf.io.gfile.GFile(mllog_path, 'r') as f:
+    for line in f:
+      if line.startswith(":::MLLOG") and "checkpoint" in line:
+        log_dict = json.loads(line[len(":::MLLOG"):])
+        step_num, timestamp = log_dict["metadata"]["step_num"], log_dict['time_ms']
+        step_num_to_timestamp[step_num] = timestamp
+
+  return step_num_to_timestamp
+
+def main():
+  args = parse_command_line_args()
+  with tf.io.gfile.GFile(args.metrics_path, 'r') as f:
+    df = pd.read_csv(f)
+
+  df = df.sort_values(by=['step_num'])
+  step_num_to_timestamp = create_step_num_to_timestamp(args.mllog_path)
+
+  success_timestamp = None
+  success_step_num = None
+  success_samples_count = None
+  for row in df.itertuples():
+    if row.fid <= args.target_fid and row.clip >= args.target_clip:
+      success_step_num = row.step_num
+      success_timestamp = step_num_to_timestamp[success_step_num]
+      success_samples_count = row.samples_count
+      mllog_utils.timestamp_fid(row.fid, success_timestamp, row.step_num, row.samples_count)
+      mllog_utils.timestamp_clip(row.clip, success_timestamp, row.step_num, row.samples_count)
+      print(f"Found checkpoint matching targets at step_num={row.step_num} samples_count={row.samples_count}: {args.target_fid=} {args.target_clip=}")
+      break
+  else:
+    print(f"Could not find checkpoint matching targets: {args.target_fid=} {args.target_clip=}")
+
+  if success_timestamp is not None:
+    mllog_utils.timestamp_run_stop_success(success_timestamp, success_step_num, success_samples_count)
+  else:
+    mllog_utils.timestamp_run_stop_abort()
+
+
+if __name__ == "__main__":
+  main()

--- a/xpk/v5p-128_e2e_mlperf.sh
+++ b/xpk/v5p-128_e2e_mlperf.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+export PLATFORM=GKE
+
+set -ex
+
+echo "Adjust Network settings and apply non cache copy"
+
+# Install ip.
+# Disable slow start after idle
+sysctl net.ipv4.tcp_slow_start_after_idle=0
+
+# Disable metrics cache
+sysctl net.ipv4.tcp_no_metrics_save=1
+
+# Address rto_min issue with two default routing entries: screen/7RGgkiXkGXSeYF2
+route=$(ip route show | sed -n 1p)
+second_route=$(ip route show | sed -n 2p)
+if [[ "${second_route}" =~ ^default.* ]]; then
+  modified_route=${route//" lock"/}
+  ip route delete ${modified_route}
+fi
+route=$(ip route show | sed -n 1p)
+echo "route rto before change: $route"
+if [[ "${route}" =~ .*lock.*5ms.* ]]; then
+  echo "${route}"
+else
+  # shellcheck disable=SC2086
+  ip route change $route rto_min 5ms
+fi
+route=$(ip route show | sed -n 1p)
+echo "route rto after change: $route"
+
+# Disable Cubic Hystart Ack-Train
+echo 2 > /sys/module/tcp_cubic/parameters/hystart_detect
+
+# Improve handling SYN burst
+echo 4096 > /proc/sys/net/core/somaxconn
+echo 4096 > /proc/sys/net/ipv4/tcp_max_syn_backlog
+
+# Disable MTU Discovery
+echo 0 > /proc/sys/net/ipv4/tcp_mtu_probing
+
+# Increase TCP Zerocopy control memory
+sysctl -w net.core.optmem_max=131072
+
+# Printing output of `ip route show`
+echo -e "\nPrinting output of 'ip route show':"
+ip route show
+
+first_line_res=$(ip route show | head -n 1)
+dev_name=$(echo "$first_line_res" | awk -F'[[:space:]]' '{ print $5 }')
+echo "dev_name=${dev_name}"
+ethtool -K "${dev_name}" tx-nocache-copy on
+
+echo "rto_setup.sh finished"
+
+export JAX_TRACEBACK_FILTERING=off
+export LIBTPU_INIT_ARGS='--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true'
+export TPU_STDERR_LOG_LEVEL=0
+export TPU_MIN_LOG_LEVEL=0
+export TF_CPP_MIN_LOG_LEVEL=0
+
+git clone -b lizhiyu/mlperf_4_mllog https://github.com/google/maxdiffusion maxdiffusion
+cd maxdiffusion
+
+pip install .
+pip install git+https://github.com/mlperf/logging.git
+
+# checkpoint interval for num of pics consumed
+CHECKPOINT_EVERY=${CHECKPOINT_EVERY:-512000}
+
+PER_DEVICE_BATCH_SIZE=${PER_DEVICE_BATCH_SIZE:-4}
+NUM_CHECKPOINTS=${NUM_CHECKPOINTS:-10}
+NUM_DEVICES=${NUM_DEVICES:-64}
+MAX_TRAIN_STEPS=${MAX_TRAIN_STEPS:-$(( $CHECKPOINT_EVERY * $NUM_CHECKPOINTS / $PER_DEVICE_BATCH_SIZE / $NUM_DEVICES ))}
+
+# training
+RUN_NAME=${RUN_NAME:-"mlperf_e2e"}
+OUTPUT_DIRECTORY=${OUTPUT_DIRECTORY:-gs://mlperf-exp/$USER/sd}
+python -m src.maxdiffusion.models.train src/maxdiffusion/configs/base_2_base.yml run_name=$RUN_NAME base_output_directory=$OUTPUT_DIRECTORY train_data_dir=gs://jfacevedo-maxdiffusion-v5p/laion400m/processed/laion400m_moments-tfrec checkpoint_every=${CHECKPOINT_EVERY} max_train_steps=$MAX_TRAIN_STEPS 2>&1 | tee /tmp/log
+sleep 30
+
+# inferencing and evaluation
+EVAL_OUT_DIR=/tmp/outputs
+mkdir -p $EVAL_OUT_DIR
+for checkpoint_dir in $(gsutil ls $OUTPUT_DIRECTORY/$RUN_NAME/checkpoints/); do
+  checkpoint_name=$(basename $checkpoint_dir)
+  mkdir -p $EVAL_OUT_DIR/$checkpoint_name
+  python -m src.maxdiffusion.eval src/maxdiffusion/configs/base_2_base.yml run_name=$RUN_NAME per_device_batch_size=16 \
+pretrained_model_name_or_path="${checkpoint_dir}" \
+caption_coco_file="gs://mlperf-exp/sd-copy/cocodata/val2014_30k_padded.tsv" \
+images_directory="$EVAL_OUT_DIR/$checkpoint_name" \
+stat_output_directory="output/" \
+stat_output_file="output/stats.npz" \
+stat_coco_file="gs://mlperf-exp/sd-copy/cocodata/val2014_30k_stats.npz" \
+clip_cache_dir="clip_cache_dir" \
+base_output_directory=$OUTPUT_DIRECTORY 2>&1 | tee -a /tmp/log
+  sleep 30
+done
+
+if [[ $(grep "MLLOG" /tmp/log | wc -l) -gt 0 ]];then
+  # TODO: remove --target-fid=500 --target-clip=0 once solving convergence issue
+  python src/maxdiffusion/report_end.py --metrics-path=${OUTPUT_DIRECTORY}/eval_metrics.csv --mllog-path=/tmp/log --target-fid=500 --target-clip=0 2>&1 | tee -a /tmp/log
+  gsutil cp /tmp/log ${OUTPUT_DIRECTORY}/log_${MEGASCALE_SLICE_ID}_${TPU_WORKER_ID}
+fi


### PR DESCRIPTION
* add mllog for inferencing and evaluation
* a `report_end.py` script to find out the earliest convergence step and print it to mllog
*  an e2e `xpk/v5p-128_e2e_mlperf.sh` to train, eval for all checkpoints, process and generate finall mllog
* tf.io is compatible to both local and gcs path, so we don't the additional step to upload/download npz and tsv 