### PR TITLE
Improve logging to remove data input overhead

### DIFF
--- a/src/maxdiffusion/configs/base_2_base.yml
+++ b/src/maxdiffusion/configs/base_2_base.yml
@@ -14,14 +14,14 @@
 
 # This sentinel is a reminder to choose a real run name.
 run_name: ''
-record_metrics: False
 metrics_file: "" # for testing, local file that stores scalar metrics. If empty, no metrics are written.
 # If true save metrics such as loss and TFLOPS to GCS in {base_output_directory}/{run_name}/metrics/
-write_metrics: False
+write_metrics: True
 gcs_metrics: False
+metrics_period: 100  # calculate step time and loss
 # If true save config to GCS in {base_output_directory}/{run_name}/
 save_config_to_gcs: False
-log_period: 10000000000
+log_period: 10000000000  # Flushes Tensorboard
 
 pretrained_model_name_or_path: 'gs://jfacevedo-maxdiffusion-v5p/stable_diffusion_checkpoints/models--stabilityai--stable-diffusion-2-base'
 unet_checkpoint: ''

--- a/src/maxdiffusion/mllog_utils.py
+++ b/src/maxdiffusion/mllog_utils.py
@@ -90,8 +90,8 @@ def train_step_end(config, step_num, samples_count, loss, lr):
       },
     )
 
-def maybe_train_step_log(config, start_step, step_num, samples_count, metric, train_log_interval: int = 100):
-  if step_num > start_step and step_num % train_log_interval == 0 or step_num == config.max_train_steps:
+def maybe_train_step_log(config, start_step, step_num, samples_count, metric):
+  if step_num > start_step:
     # convert the jax array to a numpy array for mllog JSON encoding
     loss = np.asarray(metric['scalar']['learning/loss'])
     lr = np.asarray(metric['scalar']['learning/current_learning_rate'])


### PR DESCRIPTION
* Switch to write_metrics (logging with buffer)
* add log_period. Usage suggestiong: logging will always trigger sync in jax, and break the overlapping of data input and computation. We can set log_period to a small value for debugging, but for submission, we should set to a big value, or even turn it off, only outputs at the end.
* cloud log for training 5000 steps with log_period 100: https://cloudlogging.app.goo.gl/i3a8d4LfTvzrsWqh7
* xprof: https://xprof.corp.google.com/trace_viewer/aireenmei-15432370690143073139?hosts=gke-tpu-fc96cd7e-vn72&host_index=0