### PR TITLE
Refactoring Maxdiffusion-JAX-Stable-Stack Build Process

### DIFF
--- a/.github/workflows/UploadDockerImages.yml
+++ b/.github/workflows/UploadDockerImages.yml
@@ -1,0 +1,32 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Build Images
+
+on:
+  schedule:
+    # Run the job daily at 12AM UTC
+    - cron:  '0 0 * * *'
+
+jobs:
+  build-image:
+    runs-on: ["self-hosted", "e2", "cpu"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: build jax stable stack image
+      run: |
+        bash docker_maxdiffusion_image_upload.sh PROJECT_ID=tpu-prod-env-multipod BASEIMAGE=us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/tpu:jax0.4.30-rev1 CLOUD_IMAGE_NAME=maxdiffusion-jax-stable-stack IMAGE_TAG=jax0.4.30-rev1 MAXDIFFUSION_REQUIREMENTS_FILE=requirements_with_jax_stable_stack.txt DELETE_LOCAL_IMAGE=true

--- a/maxdiffusion_jax_stable_stack_tpu.Dockerfile
+++ b/maxdiffusion_jax_stable_stack_tpu.Dockerfile
@@ -1,7 +1,7 @@
-ARG JAX_SS_BASEIMAGE
+ARG JAX_STABLE_STACK_BASEIMAGE
 
 # JAX Stable Stack Base Image
-From $JAX_SS_BASEIMAGE
+FROM $JAX_STABLE_STACK_BASEIMAGE
 
 ARG COMMIT_HASH
 
@@ -27,5 +27,5 @@ RUN if [ ! -z "${MAXDIFFUSION_REQUIREMENTS_FILE}" ]; then \
 # Install MaxDiffusion
 RUN pip install .
 
-# Run the script available in JAX-SS base image to generate the manifest file
+# Run the script available in JAX-Stable-Stack base image to generate the manifest file
 RUN bash /generate_manifest.sh PREFIX=maxdiffusion COMMIT_HASH=$COMMIT_HASH

--- a/requirements_with_jax_stable_stack.txt
+++ b/requirements_with_jax_stable_stack.txt
@@ -1,5 +1,5 @@
 # Requirements for Building the MaxDifussion Docker Image
-# These requirements are additional to the dependencies present in the JAX SS base image.
+# These requirements are additional to the dependencies present in the JAX Stable Stack base image.
 absl-py
 transformers>=4.25.1
 datasets


### PR DESCRIPTION
- Amending the workflow to build maxdiffusion with Jax-ss, which will then be used for XLML tests.
- Refactored to replace with JAX-Stable-Stack
