### PR TITLE
Qinwen/sweeping

### DIFF
--- a/src/maxdiffusion/input_pipeline/input_pipeline_interface.py
+++ b/src/maxdiffusion/input_pipeline/input_pipeline_interface.py
@@ -66,7 +66,7 @@ def make_laion400m_train_iterator(
     return tf.io.parse_single_example(example, feature_description)
 
   def prepare_sample(features):
-    moments = tf.io.parse_tensor(tnp.asarray(features["moments"]), out_type=tf.bfloat16)
+    moments = tf.io.parse_tensor(tnp.asarray(features["moments"]), out_type=tf.float32)
     captions = tf.io.parse_tensor(tnp.asarray(features["clip_embeddings"]), out_type=tf.bfloat16)
     return (moments, captions)
   
@@ -234,6 +234,6 @@ def get_shaped_batch(config, pipeline):
   #bs, encoder_input, seq_length
   batch_ids_shape = (total_train_batch_size, pipeline.text_encoder.config.max_position_embeddings, pipeline.text_encoder.config.hidden_size)
   shaped_batch = {}
-  shaped_batch["moments"] = jax.ShapeDtypeStruct(batch_image_shape, jnp.bfloat16)
+  shaped_batch["moments"] = jax.ShapeDtypeStruct(batch_image_shape, jnp.float32)
   shaped_batch["clip_embeddings"] = jax.ShapeDtypeStruct(batch_ids_shape, jnp.bfloat16)
   return shaped_batch

--- a/src/maxdiffusion/input_pipeline/input_pipeline_interface.py
+++ b/src/maxdiffusion/input_pipeline/input_pipeline_interface.py
@@ -67,7 +67,7 @@ def make_laion400m_train_iterator(
 
   def prepare_sample(features):
     moments = tf.io.parse_tensor(tnp.asarray(features["moments"]), out_type=tf.float32)
-    captions = tf.io.parse_tensor(tnp.asarray(features["clip_embeddings"]), out_type=tf.bfloat16)
+    captions = tf.io.parse_tensor(tnp.asarray(features["clip_embeddings"]), out_type=tf.float32)
     return (moments, captions)
   
   def tokenize(moments, captions, tokenizer):
@@ -235,5 +235,5 @@ def get_shaped_batch(config, pipeline):
   batch_ids_shape = (total_train_batch_size, pipeline.text_encoder.config.max_position_embeddings, pipeline.text_encoder.config.hidden_size)
   shaped_batch = {}
   shaped_batch["moments"] = jax.ShapeDtypeStruct(batch_image_shape, jnp.float32)
-  shaped_batch["clip_embeddings"] = jax.ShapeDtypeStruct(batch_ids_shape, jnp.bfloat16)
+  shaped_batch["clip_embeddings"] = jax.ShapeDtypeStruct(batch_ids_shape, jnp.float32)
   return shaped_batch

--- a/src/maxdiffusion/max_utils.py
+++ b/src/maxdiffusion/max_utils.py
@@ -518,9 +518,9 @@ def walk_and_upload_gen_images(config, output_dir, checkpoint_number="0"):
       max_logging.log(f"File {file_to_upload} moved successfully!")
 
 def save_checkpoint(pipeline, unet_state, config, output_dir):
-
-  user_dir = os.path.expanduser('~')
-  local_output_dir = output_dir.replace(os.path.join(config.base_output_directory, config.run_name), user_dir)
+  local_output_dir = output_dir.replace(os.path.join(config.base_output_directory, config.run_name), os.getcwd())
+  max_logging.log(f"saving checkpoint dir at {local_output_dir}")
+  
   pipeline.unet.save_pretrained(
     local_output_dir,
     params=get_params_to_save(unet_state.params)

--- a/src/maxdiffusion/maxdiffusion_utils.py
+++ b/src/maxdiffusion/maxdiffusion_utils.py
@@ -81,4 +81,4 @@ def calculate_unet_tflops(config, pipeline, rngs, train):
     sample=latents,
     timesteps=timesteps,
     encoder_hidden_states=encoder_hidden_states,
-    added_cond_kwargs=added_cond_kwargs)
+    added_cond_kwargs=added_cond_kwargs) / jax.local_device_count()

--- a/src/maxdiffusion/maxdiffusion_utils.py
+++ b/src/maxdiffusion/maxdiffusion_utils.py
@@ -33,7 +33,7 @@ def load_sdxllightning_unet(config, pipeline, params):
 
 def get_dummy_unet_inputs(config, pipeline):
   vae_scale_factor = 2 ** (len(pipeline.vae.config['block_out_channels']) -1)
-  batch_size = config.per_device_batch_size
+  batch_size = config.per_device_batch_size * jax.local_device_count()
   dtype=max_utils.get_dtype(config)
   input_shape = (batch_size,
                   pipeline.unet.config['in_channels'],

--- a/src/maxdiffusion/mllog_utils.py
+++ b/src/maxdiffusion/mllog_utils.py
@@ -19,7 +19,7 @@ import numpy as np
 import os
 
 mllogger = mllog.get_mllogger()
-mllog.config(filename="sd_worker.log")
+mllog.config(filename="sd_worker.log", filemode='w')
 
 def train_init_start(config):
   if jax.process_index() == 0 and config.enable_mllog:

--- a/src/maxdiffusion/mllog_utils.py
+++ b/src/maxdiffusion/mllog_utils.py
@@ -19,6 +19,7 @@ import numpy as np
 import os
 
 mllogger = mllog.get_mllogger()
+mllog.config(filename="sd_worker.log")
 
 def train_init_start(config):
   if jax.process_index() == 0 and config.enable_mllog:

--- a/src/maxdiffusion/models/train.py
+++ b/src/maxdiffusion/models/train.py
@@ -504,7 +504,7 @@ def train(config):
             last_step_completion = new_time
             last_log_step_num = step_num
 
-        if step != 0 and samples_count % config.checkpoint_every == 0:
+        if step != 0 and samples_count % config.checkpoint_every == 0 and train_metric['scalar']['learning/loss'] < 0.35:
             checkpoint_name = f"{step_num=}-{samples_count=}"
             if config.eval_at_checkpoint:
                 eval_at_checkpoint(config,

--- a/src/maxdiffusion/models/train.py
+++ b/src/maxdiffusion/models/train.py
@@ -546,6 +546,9 @@ def train(config):
         config.unet_checkpoint = checkpoint
         checkpoint_name = checkpoint.split("/")[-1]
         images_directory = os.path.join(config.images_directory, "output")
+        if os.path.isdir(images_directory):
+            shutil.rmtree(images_directory)
+            max_logging.logging(f"remove image folders under exist {images_directory}")
         os.makedirs(images_directory, exist_ok=True)
 
         generate.run(config, images_directory)

--- a/src/maxdiffusion/models/train.py
+++ b/src/maxdiffusion/models/train.py
@@ -255,7 +255,6 @@ def train(config):
         flash_block_sizes=flash_block_sizes,
         mesh=mesh,
     )
-    params = jax.tree_util.tree_map(lambda x: x.astype(weight_dtype), params)
 
     # TODO - add unit test to verify scheduler changes.
     noise_scheduler, noise_scheduler_state = max_utils.create_scheduler(config.training_scheduler, pipeline.scheduler.config, config)

--- a/src/maxdiffusion/models/train.py
+++ b/src/maxdiffusion/models/train.py
@@ -355,11 +355,11 @@ def train(config):
 
             # Add noise to the latents according to the noise magnitude at each timestep
             # (this is the forward diffusion process)
-            if config.input_peturbation > 0:
-                noisy_latents = noise_scheduler.add_noise(noise_scheduler_state, latents, new_noise, timesteps)
-            else:
-               noisy_latents = noise_scheduler.add_noise(noise_scheduler_state, latents, noise, timesteps)
-
+            # if config.input_peturbation > 0:
+            #     noisy_latents = noise_scheduler.add_noise(noise_scheduler_state, latents, new_noise, timesteps)
+            # else:
+            #    noisy_latents = noise_scheduler.add_noise(noise_scheduler_state, latents, noise, timesteps)
+            noisy_latents = latents
             # Predict the noise residual and compute loss
             model_pred = pipeline.unet.apply(
                 {"params": unet_params}, noisy_latents, timesteps, encoder_hidden_states, train=True

--- a/src/maxdiffusion/models/train.py
+++ b/src/maxdiffusion/models/train.py
@@ -355,11 +355,11 @@ def train(config):
 
             # Add noise to the latents according to the noise magnitude at each timestep
             # (this is the forward diffusion process)
-            # if config.input_peturbation > 0:
-            #     noisy_latents = noise_scheduler.add_noise(noise_scheduler_state, latents, new_noise, timesteps)
-            # else:
-            #    noisy_latents = noise_scheduler.add_noise(noise_scheduler_state, latents, noise, timesteps)
-            noisy_latents = latents
+            if config.input_peturbation > 0:
+                noisy_latents = noise_scheduler.add_noise(noise_scheduler_state, latents, new_noise, timesteps)
+            else:
+               noisy_latents = noise_scheduler.add_noise(noise_scheduler_state, latents, noise, timesteps)
+
             # Predict the noise residual and compute loss
             model_pred = pipeline.unet.apply(
                 {"params": unet_params}, noisy_latents, timesteps, encoder_hidden_states, train=True

--- a/src/maxdiffusion/models/vae_flax.py
+++ b/src/maxdiffusion/models/vae_flax.py
@@ -906,17 +906,11 @@ class FlaxAutoencoderKL(nn.Module, FlaxModelMixin, ConfigMixin):
         else:
             return self.init(rngs, sample)["params"]
 
-    def moments(self, sample, deterministic: bool = True):
+    def encode(self, sample, deterministic: bool = True, return_dict: bool = True):
         sample = jnp.transpose(sample, (0, 2, 3, 1))
 
         hidden_states = self.encoder(sample, deterministic=deterministic)
         moments = self.quant_conv(hidden_states)
-        return moments
-
-
-    def encode(self, sample, deterministic: bool = True, return_dict: bool = True):
-        
-        moments = self.moments(sample, deterministic)
         posterior = FlaxDiagonalGaussianDistribution(moments)
 
         if not return_dict:

--- a/src/maxdiffusion/pedagogical_examples/to_tfrecords.py
+++ b/src/maxdiffusion/pedagogical_examples/to_tfrecords.py
@@ -24,7 +24,7 @@ python src/maxdiffusion/pedagogical_examples/to_tfrecords.py \
   src/maxdiffusion/configs/base_2_base.yml attention=dot_product \
   data_files_pattern=/mnt/data/webdataset-moments-filtered/*.tar \
   extracted_files_dir=/tmp/raw-data-extracted \
-  tfrecords_dir=/mnt/data/tf_records_512_encoder_state \
+  tfrecords_dir=/mnt/data/tf_records_512_encoder_state_fp32 \
   run_name=test no_records_per_shard=12720 base_output_directory=/tmp/output > result_512_encode.txt
 """
 
@@ -94,8 +94,7 @@ def tokenize_captions(caption, pipeline, p_encode):
                                     padding="max_length",
                                     truncation=True)
    hidden_states = p_encode(np.stack(text_inputs.input_ids))
-   hidden_states = jnp.squeeze(hidden_states).astype(jnp.bfloat16)
-   print(hidden_states.shape)
+   hidden_states = jnp.squeeze(hidden_states).astype(jnp.float32)
    return hidden_states
 
 def generate_dataset(config):

--- a/src/maxdiffusion/pedagogical_examples/to_tfrecords.py
+++ b/src/maxdiffusion/pedagogical_examples/to_tfrecords.py
@@ -22,9 +22,9 @@ Example file of how to prepare tfrecords with latents and hidden_states preproce
 3. Run this file:
 python src/maxdiffusion/pedagogical_examples/to_tfrecords.py \
   src/maxdiffusion/configs/base_2_base.yml attention=dot_product \
-  data_files_pattern=/mnt/disks/laion400-disk/webdataset-filtered-images/*.tar \
+  data_files_pattern=/mnt/data/webdataset-moments-filtered/*.tar \
   extracted_files_dir=/tmp/raw-data-extracted \
-  tfrecords_dir=/mnt/disks/laion400-disk/tf_records_processed_512_encoder_state \
+  tfrecords_dir=/mnt/data/tf_records_512_encoder_state \
   run_name=test no_records_per_shard=12720 base_output_directory=/tmp/output > result_512_encode.txt
 """
 
@@ -37,6 +37,7 @@ import time
 import tarfile
 import tensorflow as tf
 from torchvision import transforms
+import tensorflow_datasets as tfds
 import numpy as np
 import jax
 import jax.numpy as jnp
@@ -50,15 +51,6 @@ from maxdiffusion import (
   FlaxStableDiffusionPipeline,
   pyconfig,
   max_utils
-)
-
-TRANSFORMS = transforms.Compose(
-  [
-    transforms.ToTensor(),
-    transforms.Resize(size=512, interpolation=transforms.InterpolationMode.BICUBIC),
-    transforms.CenterCrop(size=512),
-    transforms.Normalize([0.5], [0.5])
-  ]
 )
 
 def image_feature(value):
@@ -86,11 +78,11 @@ def float_feature_list(value):
     """Returns a list of float_list from a float / double."""
     return tf.train.Feature(float_list=tf.train.FloatList(value=value))
 
-def create_example(moments, hidden_states):
-    moments = tf.io.serialize_tensor(moments)
+def create_example(latent, hidden_states):
+    latent = tf.io.serialize_tensor(latent)
     hidden_states = tf.io.serialize_tensor(hidden_states)
     feature = {
-        "moments": bytes_feature(moments),
+        "moments": bytes_feature(latent),
         "clip_embeddings": bytes_feature(hidden_states),
     }
     example = tf.train.Example(features=tf.train.Features(feature=feature))
@@ -103,22 +95,8 @@ def tokenize_captions(caption, pipeline, p_encode):
                                     truncation=True)
    hidden_states = p_encode(np.stack(text_inputs.input_ids))
    hidden_states = jnp.squeeze(hidden_states).astype(jnp.bfloat16)
+   print(hidden_states.shape)
    return hidden_states
-
-def vae_apply(images, vae, vae_params):
-  moments = vae.apply(
-    {"params" : vae_params},
-    images,deterministic=True,
-    method=vae.moments
-  )
-  return moments
-
-def img_to_moments(img, p_vae_apply):
-  img = TRANSFORMS(img)
-  img = np.expand_dims(np.array(img), axis=0)
-  moments = p_vae_apply(img)
-  moments = jnp.squeeze(moments).astype(jnp.bfloat16)
-  return moments
 
 def generate_dataset(config):
   tfrecords_dir=config.tfrecords_dir
@@ -143,8 +121,6 @@ def generate_dataset(config):
                                         text_encoder=pipeline.text_encoder,
                                         text_encoder_params=params["text_encoder"]))
 
-  p_vae_apply = jax.jit(functools.partial(vae_apply, vae=pipeline.vae, vae_params=params["vae"]))
-
   tf_rec_num = 0
   filenames = tf.io.gfile.glob(config.data_files_pattern)
   no_records_per_shard = config.no_records_per_shard
@@ -160,12 +136,15 @@ def generate_dataset(config):
     start = time.time()
     file = tarfile.open(filename)
     file.extractall(extract_to_folder, filter='data')
-    extracted_filenames = tf.io.gfile.glob(f"{extract_to_folder}/*.jpg")
-    for image_file in extracted_filenames:
-      img = Image.open(image_file).convert("RGB")
-      moments = img_to_moments(img, p_vae_apply)
-      caption_file = image_file.split(".")[0] + ".txt"
-      json_file = image_file.split(".")[0] + ".json"
+    extracted_filenames = tf.io.gfile.glob(f"{extract_to_folder}/*.npy")
+    for moments_file in extracted_filenames:
+      moments = np.load(moments_file)
+      moments = np.squeeze(moments)
+      # Moments generated with Pytorch which is Channel first.
+      # CWH -> WHC
+      moments = moments.transpose((1,2,0))
+      caption_file = moments_file.split(".")[0] + ".txt"
+      json_file = moments_file.split(".")[0] + ".json"
       with open(caption_file, "r") as f:
         caption = f.read()
 
@@ -174,7 +153,7 @@ def generate_dataset(config):
       writer.write(example)
       shard_record_count+=1
       global_record_count+=1
-      os.remove(image_file)
+      os.remove(moments_file)
       os.remove(caption_file)
       os.remove(json_file)
       if shard_record_count >= no_records_per_shard:
@@ -192,7 +171,26 @@ def encode(input_ids, text_encoder, text_encoder_params):
     train=False
   )[0]
 
+def vae_apply(images, sample_rng, vae, vae_params):
+  vae_outputs = vae.apply(
+    {"params" : vae_params},
+    images,deterministic=True,
+    method=vae.encode
+  )
+  latents = vae_outputs.latent_dist.sample(sample_rng)
+  latents = jnp.transpose(latents, (0, 3, 1, 2))
+  latents = latents * vae.config.scaling_factor
+  return latents
+
+def img_to_latents(img, p_vae_apply, sample_rng):
+  img = TRANSFORMS(img)
+  img = np.expand_dims(np.array(img), axis=0)
+  latents = p_vae_apply(img, sample_rng)
+  latents = jnp.squeeze(latents)
+  return latents
+
 def run(config):
+
   generate_dataset(config)
 
 def main(argv: Sequence[str]) -> None:

--- a/src/maxdiffusion/pyconfig.py
+++ b/src/maxdiffusion/pyconfig.py
@@ -88,6 +88,8 @@ class _HyperParameters():
 
     _HyperParameters.user_init(raw_keys)
     self.keys = raw_keys
+    for k in raw_keys:
+      max_logging.log(f"Config param {k}: {raw_keys[k]}")
 
   def _load_kwargs(self, argv: list[str], **kwargs):
     args_dict = dict(a.split("=", 1) for a in argv[2:])

--- a/src/maxdiffusion/report_end.py
+++ b/src/maxdiffusion/report_end.py
@@ -50,7 +50,7 @@ def create_step_num_to_timestamp(mllog_path: str):
     for line in f:
       if line.startswith(":::MLLOG"):
         log_dict = json.loads(line[len(":::MLLOG"):])
-        if log_dict["key"] == "checkpoint":
+        if log_dict["key"] == "block_stop":
           step_num, timestamp = log_dict["metadata"]["step_num"], log_dict['time_ms']
           step_num_to_timestamp[step_num] = timestamp
 


### PR DESCRIPTION
* Data back to unormalized fp32:
* Address extra aot compilation after log metric enabled
* Address report time not include last checkpoint saving
* AOT enabling followed from Juan's suggestion by adapting batch size.
* Add criteria for eval for mlperf loss < 0.35 to speed up sweeping. 